### PR TITLE
Fixes fabric prompt import

### DIFF
--- a/src/parllama/prompt_utils/import_fabric.py
+++ b/src/parllama/prompt_utils/import_fabric.py
@@ -113,7 +113,7 @@ class ImportFabricManager(ParEventSystemBase):
                 # Validate expected structure
                 if progress_callback:
                     progress_callback(45, "Validating structure...", "Checking for patterns folder")
-                patterns_source_path = os.path.join(extracted_folder_path, "fabric-main", "patterns")
+                patterns_source_path = os.path.join(extracted_folder_path, "Fabric-main", "data", "patterns")
                 if not os.path.exists(patterns_source_path):
                     raise FileNotFoundError("Patterns folder not found in the downloaded zip.")
 


### PR DESCRIPTION
Recently the directory structure for Fabric changed.  This updates the import_fabric script to reflect the new structure.