### PR TITLE
fix(ci): publish to PyPI when TestPyPI is skipped

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -259,7 +259,12 @@ jobs:
     name: Publish to PyPI 🎉
     runs-on: ubuntu-latest
     needs: [build-and-tag, github-release]
-    if: needs.github-release.result == 'success'
+    # `always()` is required: github-release depends on publish-testpypi, so when
+    # skip-testpypi=true (publish-testpypi skipped) the default success() check
+    # would skip this job too -- defeating the "go straight to release" path.
+    # The explicit gate below still restricts PyPI to runs where the signed
+    # release artifacts were actually created.
+    if: always() && needs.github-release.result == 'success'
     environment:
       name: pypi
       url: https://pypi.org/p/parllama


### PR DESCRIPTION
## Problem

The `Release Pipeline 🚀` workflow has a `skip-testpypi` input described as *"Skip TestPyPI publication (go straight to release)"* — but it never actually reached PyPI. When `skip-testpypi=true`:

| Stage | Result |
|---|---|
| Build and Create Tag | ✅ success |
| Publish to TestPyPI | ⏭️ skipped (intended) |
| Create GitHub Release | ✅ success |
| **Publish to PyPI** | ⏭️ **skipped (BUG)** |

Observed in the wild while releasing v0.9.1: the GitHub Release was created but PyPI never received the package. Re-running with TestPyPI enabled published correctly, confirming the skip was the cause.

## Root cause

`publish-pypi` was gated only by:

```yaml
if: needs.github-release.result == 'success'
```

With no status-check function, GitHub Actions applies the implicit `success()` check. Because `github-release` declares `needs: [build-and-tag, publish-testpypi]`, a skipped `publish-testpypi` propagates through the `needs` graph and auto-skips `publish-pypi` — regardless of the explicit condition. (This is the same class of skip `github-release` itself already avoids by using `always()`.)

## Fix

Prepend `always()` so the job is evaluated on its own gate instead of the implicit transitive check:

```yaml
if: always() && needs.github-release.result == 'success'
```

PyPI still only publishes when `github-release` succeeded (signed artifacts created). Traced both paths:

- `skip-testpypi=false` → TestPyPI success → github-release success → **publish-pypi runs** ✅
- `skip-testpypi=true`  → TestPyPI skipped → github-release success → **publish-pypi runs** ✅ (fixed)

If `build-and-tag` fails, `github-release` is skipped/failed → `needs.github-release.result != 'success'` → publish-pypi stays skipped. Safety preserved.

## Verification

YAML parses (`yaml.safe_load`). After merge I will trigger the pipeline with `skip-testpypi=true` against the already-released v0.9.1 (all steps are idempotent via existence checks / `skip-existing`) to confirm `Publish to PyPI 🎉` now executes instead of skipping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing behavior so the PyPI publish step still runs correctly in direct-release scenarios, even when an earlier release step is skipped.
  * Kept the publish step guarded to only proceed after a successful release stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->